### PR TITLE
Add HttpResponseMessage curl visualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # CurlDebuggerVisualizer
+
+This repository contains a Visual Studio debugger visualizer that displays the
+`HttpRequestMessage` associated with an `HttpResponseMessage` in cURL format.
+
+## Usage
+
+1. Build the `CurlDebuggerVisualizer` project to produce a `.vsix` package.
+2. Install the generated `CurlDebuggerVisualizer.vsix` by double-clicking it or
+   using the `Extensions > Manage Extensions` dialog in Visual Studio 2022 or
+   newer.
+3. While debugging, use the magnifier icon next to an `HttpResponseMessage` to
+   view the request as a cURL command.
+
+The visualizer converts the request method, URL, headers and body into a cURL
+command that can be pasted into a terminal for troubleshooting.

--- a/src/CurlDebuggerVisualizer/CurlDebuggerVisualizer.csproj
+++ b/src/CurlDebuggerVisualizer/CurlDebuggerVisualizer.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <AssemblyName>CurlDebuggerVisualizer</AssemblyName>
+    <RootNamespace>CurlDebuggerVisualizer</RootNamespace>
+    <OutputType>Library</OutputType>
+    <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
+    <VsixContainer>true</VsixContainer>
+    <GeneratePkgDefFile>false</GeneratePkgDefFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.DebuggerVisualizers" Version="17.0.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Windows.Forms" Version="4.7.0" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.8.10" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="source.extension.vsixmanifest" />
+  </ItemGroup>
+</Project>

--- a/src/CurlDebuggerVisualizer/CurlRequestFormatter.cs
+++ b/src/CurlDebuggerVisualizer/CurlRequestFormatter.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+
+namespace CurlDebuggerVisualizer
+{
+    internal static class CurlRequestFormatter
+    {
+        public static string ToCurl(HttpRequestMessage request)
+        {
+            var sb = new StringBuilder();
+            sb.Append("curl");
+
+            sb.Append(" -X ").Append(request.Method);
+            sb.Append(' ').Append("\"").Append(request.RequestUri).Append("\"");
+
+            foreach (var header in request.Headers)
+            {
+                foreach (var value in header.Value)
+                {
+                    sb.Append(" -H \"").Append(header.Key).Append(": ").Append(value).Append("\"");
+                }
+            }
+
+            if (request.Content != null)
+            {
+                foreach (var header in request.Content.Headers)
+                {
+                    foreach (var value in header.Value)
+                    {
+                        sb.Append(" -H \"").Append(header.Key).Append(": ").Append(value).Append("\"");
+                    }
+                }
+
+                var body = request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                if (!string.IsNullOrEmpty(body))
+                {
+                    sb.Append(" --data \"").Append(body.Replace("\"", "\\\"")).Append("\"");
+                }
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/CurlDebuggerVisualizer/CurlResponseVisualizer.cs
+++ b/src/CurlDebuggerVisualizer/CurlResponseVisualizer.cs
@@ -1,0 +1,51 @@
+using Microsoft.VisualStudio.DebuggerVisualizers;
+using System;
+using System.Net.Http;
+using System.Windows.Forms;
+
+[assembly: System.Diagnostics.DebuggerVisualizer(
+    typeof(CurlDebuggerVisualizer.CurlResponseVisualizer),
+    typeof(CurlDebuggerVisualizer.HttpResponseVisualizerObjectSource),
+    Target = typeof(HttpResponseMessage),
+    Description = "cURL request")]
+
+namespace CurlDebuggerVisualizer
+{
+    public class CurlResponseVisualizer : DialogDebuggerVisualizer
+    {
+        protected override void Show(IDialogVisualizerService windowService, IVisualizerObjectProvider objectProvider)
+        {
+            if (objectProvider == null) throw new ArgumentNullException(nameof(objectProvider));
+            var request = (HttpRequestMessage)objectProvider.GetObject();
+            string curl = CurlRequestFormatter.ToCurl(request);
+
+            using (var form = new Form())
+            using (var textBox = new TextBox())
+            {
+                form.Text = "cURL";
+                textBox.Multiline = true;
+                textBox.ReadOnly = true;
+                textBox.Dock = DockStyle.Fill;
+                textBox.Text = curl;
+                form.ClientSize = new System.Drawing.Size(800, 450);
+                form.Controls.Add(textBox);
+                windowService.ShowDialog(form);
+            }
+        }
+    }
+
+    public class HttpResponseVisualizerObjectSource : VisualizerObjectSource
+    {
+        public override void GetData(object target, System.IO.Stream outgoingData)
+        {
+            if (target is HttpResponseMessage response && response.RequestMessage != null)
+            {
+                base.GetData(response.RequestMessage, outgoingData);
+            }
+            else
+            {
+                base.GetData(null, outgoingData);
+            }
+        }
+    }
+}

--- a/src/CurlDebuggerVisualizer/source.extension.vsixmanifest
+++ b/src/CurlDebuggerVisualizer/source.extension.vsixmanifest
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Vsix xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
+  <Identifier Id="CurlDebuggerVisualizer">
+    <Name>Curl Debugger Visualizer</Name>
+    <Author>OpenAI</Author>
+    <Version>1.0</Version>
+    <Description xml:space="preserve">Displays an HttpResponseMessage's request as a cURL command.</Description>
+    <SupportedProducts>
+      <VisualStudio Version="17.0">
+        <Edition>Community</Edition>
+        <Edition>Professional</Edition>
+        <Edition>Enterprise</Edition>
+      </VisualStudio>
+    </SupportedProducts>
+    <Content>
+      <CustomExtension Type="DebuggerVisualizer">CurlDebuggerVisualizer.dll</CustomExtension>
+    </Content>
+  </Identifier>
+</Vsix>


### PR DESCRIPTION
## Summary
- add vsix manifest and packaging to install as a Visual Studio extension
- reference Microsoft.VSSDK.BuildTools for VSIX generation
- update README with installation steps for VS 2022+

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415ef552b0833392ddd79dcf5b6219