### PR TITLE
Improve README usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ This repository contains a Visual Studio debugger visualizer that displays the
 
 ## Usage
 
-1. Build the `CurlDebuggerVisualizer` project.
-2. Copy the generated `CurlDebuggerVisualizer.dll` into the Visual Studio
-   visualizers directory (e.g., `%USERPROFILE%\Documents\Visual Studio 2022\Visualizers`).
+1. Download the latest `CurlDebuggerVisualizer.vsix` from the project's [releases page](../../releases)
+   or build the VSIX yourself by building the solution.
+2. Install the extension and restart Visual Studio. Alternatively, copy the
+   generated `CurlDebuggerVisualizer.dll` into the Visual Studio visualizers
+   directory (e.g., `%USERPROFILE%\Documents\Visual Studio 2022\Visualizers`).
 3. While debugging, use the magnifier icon next to an `HttpResponseMessage` to
    view the request as a cURL command.
 


### PR DESCRIPTION
## Summary
- mention the releases page for downloading the VSIX
- provide alternate instructions for building and installing the extension

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841672616cc8333992fe4ce1583538f