### PR TITLE
Fix project build on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,14 +5,17 @@ on:
   pull_request:
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
       - name: Build
-        run: dotnet build src/CurlDebuggerVisualizer/CurlDebuggerVisualizer.csproj -c Release
+        run: msbuild src/CurlDebuggerVisualizer/CurlDebuggerVisualizer.csproj /p:Configuration=Release
       - name: Upload VSIX
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -1,50 +1,17 @@
 # CurlDebuggerVisualizer
 
-This repository contains a Visual Studio debugger visualizer that displays the
-`HttpRequestMessage` associated with an `HttpResponseMessage` in cURL format.
-
-## Usage
-
-1. Download the latest `CurlDebuggerVisualizer.vsix` from the project's [releases page](../../releases)
-   or build the VSIX yourself by building the solution.
-2. Install the extension and restart Visual Studio. Alternatively, copy the
-   generated `CurlDebuggerVisualizer.dll` into the Visual Studio visualizers
-   directory (e.g., `%USERPROFILE%\Documents\Visual Studio 2022\Visualizers`).
-
- 
-1. Build the `CurlDebuggerVisualizer` project to produce the VSIX package:
-
-   ```bash
-   dotnet build src/CurlDebuggerVisualizer/CurlDebuggerVisualizer.csproj -c Release
-   ```
-
-   The package `CurlDebuggerVisualizer.vsix` will be created under
-   `src/CurlDebuggerVisualizer/bin/Release`. You can also download a prebuilt
-   version from the project's GitHub Releases page.
-2. Install the `CurlDebuggerVisualizer.vsix` by double-clicking it or using the
-   `Extensions > Manage Extensions` dialog in Visual Studio 2022 or newer.
-3. While debugging, use the magnifier icon next to an `HttpResponseMessage` to
-   view the request as a cURL command.
-
-The visualizer converts the request method, URL, headers and body into a cURL
-command that can be pasted into a terminal for troubleshooting.
-This repository contains a Visual Studio debugger visualizer that displays the `HttpRequestMessage` associated with an `HttpResponseMessage` in cURL format.
+CurlDebuggerVisualizer is a Visual Studio debugger visualizer that shows the `HttpRequestMessage` behind an `HttpResponseMessage` as a cURL command.
 
 ## Building
 
-Run `dotnet build` from the repository root to generate the extension. This command produces a `CurlDebuggerVisualizer.vsix` file.
+The project uses the Visual Studio SDK to create a VSIX package and therefore must be built on Windows. Run the following command to produce `CurlDebuggerVisualizer.vsix`:
 
-1. Build the `CurlDebuggerVisualizer` project to produce a `.vsix` package.
-2. Install the generated `CurlDebuggerVisualizer.vsix` by double-clicking it or
-   using the `Extensions > Manage Extensions` dialog in Visual Studio 2022 or
-   newer.
-3. While debugging, use the magnifier icon next to an `HttpResponseMessage` to
-   view the request as a cURL command.
+```bash
+msbuild src/CurlDebuggerVisualizer/CurlDebuggerVisualizer.csproj /p:Configuration=Release
+```
 
-If you prefer not to build the project yourself, download the VSIX from the releases page of this repository.
+The file will be placed under `src/CurlDebuggerVisualizer/bin/Release`.
 
 ## Installation and Usage
 
-Install the VSIX in Visual Studio. When debugging an `HttpResponseMessage`, use the magnifier icon to view the request as a cURL command.
-
-The visualizer converts the request method, URL, headers and body into a cURL command that can be pasted into a terminal for troubleshooting.
+Install the generated VSIX in Visual Studio 2022 or newer. When debugging an `HttpResponseMessage`, use the magnifier icon to view the request as a cURL command that can be pasted into a terminal for troubleshooting.

--- a/src/CurlDebuggerVisualizer/CurlDebuggerVisualizer.csproj
+++ b/src/CurlDebuggerVisualizer/CurlDebuggerVisualizer.csproj
@@ -10,15 +10,17 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.DebuggerVisualizers" Version="17.0.0" />
-
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Windows.Forms" Version="4.7.0" />
+    <!-- System.Net.Http and System.Windows.Forms are provided by the .NET Framework -->
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.8.10" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <None Include="source.extension.vsixmanifest" />
-  </PropertyGroup>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- change CI to build on Windows with MSBuild
- rewrite README with simplified build instructions

## Testing
- `dotnet build src/CurlDebuggerVisualizer/CurlDebuggerVisualizer.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841702f58c08333a1f4f12f73be6864